### PR TITLE
fix: Fix type for oidc_verify_cert

### DIFF
--- a/provider/resource_config_auth.go
+++ b/provider/resource_config_auth.go
@@ -39,7 +39,7 @@ func resourceConfigAuth() *schema.Resource {
 				Optional: true,
 			},
 			"oidc_verify_cert": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeBool,
 				Optional: true,
 			},
 		},


### PR DESCRIPTION
Hello, 

Because of this type error. the `harbor_config_auth` resource is not working, with this stack : 

```
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: goroutine 32 [running]:
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: github.com/BESTSELLER/terraform-provider-harbor/client.GetConfigAuth(0xc00027f180, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: 	github.com/BESTSELLER/terraform-provider-harbor/client/config.go:25 +0x465
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: github.com/BESTSELLER/terraform-provider-harbor/provider.resourceConfigAuthCreate(0xc00027f180, 0xeb97e0, 0xc000414300, 0x2, 0x1717740)
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: 	github.com/BESTSELLER/terraform-provider-harbor/provider/resource_config_auth.go:56 +0x5b
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0xc000118120, 0xc000673130, 0xc0004a71a0, 0xeb97e0, 0xc000414300, 0xe8e701, 0xc0000a7cb8, 0xc000428d80)
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: 	github.com/hashicorp/terraform-plugin-sdk@v1.15.0/helper/schema/resource.go:310 +0x375
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Provider).Apply(0xc00012e100, 0xc000615a10, 0xc000673130, 0xc0004a71a0, 0xc0000c7168, 0xc0004ec400, 0xe90300)
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: 	github.com/hashicorp/terraform-plugin-sdk@v1.15.0/helper/schema/provider.go:294 +0x99
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ApplyResourceChange(0xc000126048, 0x114ba20, 0xc000428240, 0xc00027eaf0, 0xc000126048, 0xc000428240, 0xc00066ab78)
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: 	github.com/hashicorp/terraform-plugin-sdk@v1.15.0/internal/helper/plugin/grpc_provider.go:885 +0x8ab
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0xf94b20, 0xc000126048, 0x114ba20, 0xc000428240, 0xc00011b080, 0x0, 0x114ba20, 0xc000428240, 0xc000418840, 0x29d)
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: 	github.com/hashicorp/terraform-plugin-sdk@v1.15.0/internal/tfplugin5/tfplugin5.pb.go:3305 +0x214
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: google.golang.org/grpc.(*Server).processUnaryRPC(0xc000512c00, 0x1154aa0, 0xc000642600, 0xc000132400, 0xc000494810, 0x16d6740, 0x0, 0x0, 0x0)
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: 	google.golang.org/grpc@v1.27.1/server.go:1024 +0x522
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: google.golang.org/grpc.(*Server).handleStream(0xc000512c00, 0x1154aa0, 0xc000642600, 0xc000132400, 0x0)
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: 	google.golang.org/grpc@v1.27.1/server.go:1313 +0xd34
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0005021b0, 0xc000512c00, 0x1154aa0, 0xc000642600, 0xc000132400)
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: 	google.golang.org/grpc@v1.27.1/server.go:722 +0xa5
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: created by google.golang.org/grpc.(*Server).serveStreams.func1
2020-10-07T16:49:16.125+0200 [DEBUG] plugin.terraform-provider-harbor_v0.4.1: 	google.golang.org/grpc@v1.27.1/server.go:720 +0xa5
2020/10/07 16:49:16 [DEBUG] harbor_config_auth.gsuite: apply errored, but we're indicating that via the Error pointer rather than returning it: rpc error: code = Unavailable desc = transport is closing
```

Cheers