### PR TITLE
Fix typo for label field in filters

### DIFF
--- a/provider/resource_replication.go
+++ b/provider/resource_replication.go
@@ -61,7 +61,7 @@ func resourceReplication() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"labels": {
+						"label": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},


### PR DESCRIPTION
The field is called "label" and not "labels", this is reflected in the UI and the rest of the code.