### PR TITLE
oidc configuration: add automatic onboarding + username claim options

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -23,6 +23,8 @@ func GetConfigAuth(d *schema.ResourceData) models.ConfigBodyPost {
 		OidcGroupsClaim:  d.Get("oidc_groups_claim").(string),
 		OidcScope:        d.Get("oidc_scope").(string),
 		OidcVerifyCert:   d.Get("oidc_verify_cert").(bool),
+		OidcAutoOnboard:  d.Get("oidc_auto_onboard").(bool),
+		OidcUserClaim:    d.Get("oidc_user_claim").(string),
 	}
 }
 

--- a/docs/resources/configuration.md
+++ b/docs/resources/configuration.md
@@ -11,6 +11,8 @@ resource "harbor_config_auth" "oidc" {
   oidc_client_secret = "ODDC Client Secret goes here"
   oidc_scope         = "openid,email"
   oidc_verify_cert   = true
+  oidc_auto_onboard  = true
+  oidc_user_claim    = "name"
 }
 ```
 
@@ -34,3 +36,7 @@ The following arguments are supported:
 * **oidc_scope** - (Optional) The scope sent to OIDC server during authentication. It has to contain “openid”. (Required - if auth_mode set to **oidc_auth**)
 
 * **oidc_verify_cert** - (Optional) Set to **"false"** if your OIDC server is using a self-signed certificate. (Required - if auth_mode set to **oidc_auth**)
+
+* **oidc_auto_onboard** - (Optional) Default is **"false"**, set to **"true"** if you want to skip the user onboarding screen, so user cannot change its username
+
+* **oidc_user_claim** - (Optional) Default is **"name"**

--- a/models/config.go
+++ b/models/config.go
@@ -4,6 +4,8 @@ var PathConfig = "/configurations"
 
 type ConfigBodyPost struct {
 	OidcVerifyCert        bool   `json:"oidc_verify_cert"`
+	OidcAutoOnboard       bool   `json:"oidc_auto_onboard"`
+	OidcUserClaim         string `json:"oidc_user_claim,omitempty"`
 	EmailIdentity         string `json:"email_identity,omitempty"`
 	LdapGroupSearchFilter string `json:"ldap_group_search_filter,omitempty"`
 	AuthMode              string `json:"auth_mode,omitempty"`
@@ -52,6 +54,14 @@ type ConfigBodyResponse struct {
 		Editable bool `json:"editable,omitempty"`
 		Value    bool `json:"value,omitempty"`
 	} `json:"oidc_verify_cert,omitempty"`
+	OidcAutoOnboard struct {
+		Editable bool `json:"editable,omitempty"`
+		Value    bool `json:"value,omitempty"`
+	} `json:"oidc_auto_onboard,omitempty"`
+	OidcUserClaim struct {
+		Editable bool   `json:"editable,omitempty"`
+		Value    string `json:"value,omitempty"`
+	} `json:"oidc_user_claim,omitempty"`
 	EmailIdentity struct {
 		Editable bool   `json:"editable,omitempty"`
 		Value    string `json:"value,omitempty"`

--- a/provider/resource_config_auth.go
+++ b/provider/resource_config_auth.go
@@ -42,6 +42,14 @@ func resourceConfigAuth() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"oidc_auto_onboard": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"oidc_user_claim": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 		Create: resourceConfigAuthCreate,
 		Read:   resourceConfigAuthRead,


### PR DESCRIPTION
Hi,
this PR is to add those 2 parameters in the OIDC configuration :
![image](https://user-images.githubusercontent.com/11298399/98942078-c5d74280-24ed-11eb-9ae4-f9fe8739c2a4.png)
