### PR TITLE
fix(docs): typos

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -2,7 +2,7 @@
 
 ## Example Usage
 ```hcl
-data "haror_project" "main" {
+data "harbor_project" "main" {
     name    = "library" 
 }
 

--- a/docs/resources/configuration.md
+++ b/docs/resources/configuration.md
@@ -25,9 +25,9 @@ The following arguments are supported:
 
 * **oidc_endpoint** - (Optional) The URL of an OIDC-complaint server. (Required - if auth_mode set to **oidc_auth**)
 
-* **oidc_client_id** - (Optional) The client id for the odic server. (Required - if auth_mode set to **oidc_auth**)
+* **oidc_client_id** - (Optional) The client id for the oidc server. (Required - if auth_mode set to **oidc_auth**)
 
-* **oidc_client_serect** - (Optional) The client secert for the odic server. (Required - if auth_mode set to **oidc_auth**)
+* **oidc_client_serect** - (Optional) The client secert for the oidc server. (Required - if auth_mode set to **oidc_auth**)
 
 * **oidc_groups_claim** - (Optional) The name of the claim in the token whose values is the list of group names.
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -2,7 +2,7 @@
 
 ## Example Usage
 ```hcl
-resource "haror_project" "main" {
+resource "harbor_project" "main" {
     name                    = "main"
     public                  = false               # (Optional) Default value is false
     vulnerability_scanning  = true                # (Optional) Default vale is true. Automatically scan images on push 
@@ -27,5 +27,5 @@ In addition to all argument, the folloing attributes are exported:
 Harbor project can be imported using the `project id` eg,
 
 `
-terraform import haror_project.main /projects/1
+terraform import harbor_project.main /projects/1
 `

--- a/docs/resources/project_member.md
+++ b/docs/resources/project_member.md
@@ -4,7 +4,7 @@
 
 ## Example Usage
 ```hcl
-resource "haror_project" "main" {
+resource "harbor_project" "main" {
     name = "main"
 }
 
@@ -28,4 +28,4 @@ The following arguments are supported:
 
 * **type** - (Requried) The group type.  Can be set to **"ldap"**, **"internal"** or **"oidc"** 
 
-`NOTE: odic group type can only be used with harbor version v1.10.1 and above`
+`NOTE: oidc group type can only be used with harbor version v1.10.1 and above`

--- a/docs/resources/project_member_group.md
+++ b/docs/resources/project_member_group.md
@@ -2,7 +2,7 @@
 
 ## Example Usage
 ```hcl
-resource "haror_project" "main" {
+resource "harbor_project" "main" {
     name = "main"
 }
 
@@ -26,4 +26,4 @@ The following arguments are supported:
 
 * **type** - (Requried) The group type.  Can be set to **"ldap"**, **"internal"** or **"oidc"** 
 
-`NOTE: odic group type can only be used with harbor version v1.10.1 and above`
+`NOTE: oidc group type can only be used with harbor version v1.10.1 and above`

--- a/docs/resources/project_member_user.md
+++ b/docs/resources/project_member_user.md
@@ -2,7 +2,7 @@
 
 ## Example Usage
 ```hcl
-resource "haror_project" "main" {
+resource "harbor_project" "main" {
     name = "main"
 }
 

--- a/docs/resources/registry.md
+++ b/docs/resources/registry.md
@@ -42,5 +42,5 @@ In addition to all argument, the folloing attributes are exported:
 Harbor project can be imported using the `registry id` eg,
 
 `
-terraform import haror_project.main /registries/7
+terraform import harbor_project.main /registries/7
 `

--- a/docs/resources/replication.md
+++ b/docs/resources/replication.md
@@ -55,5 +55,5 @@ In addition to all argument, the folloing attributes are exported:
 Harbor project can be imported using the `replication id` eg,
 
 `
-terraform import haror_project.main /registries/7
+terraform import harbor_project.main /registries/7
 `

--- a/docs/resources/robot_account.md
+++ b/docs/resources/robot_account.md
@@ -2,7 +2,7 @@
 
 ## Example Usage
 ```hcl
-resource "haror_project" "main" {
+resource "harbor_project" "main" {
     name = "main"
 }
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -30,5 +30,5 @@ The following arguments are supported:
 An internal user harbor user can be imported using the `user id` eg,
 
 `
-terraform import haror_user.main /users/19
+terraform import harbor_user.main /users/19
 `


### PR DESCRIPTION
Fixes the following typos:

- haror_ -> harbor_
- odic -> oidc