### PR TITLE
feature: allow selecting numeric group ID

### DIFF
--- a/client/project_members.go
+++ b/client/project_members.go
@@ -11,6 +11,7 @@ func ProjectMembersGroupBody(d *schema.ResourceData) models.ProjectMembersBody {
 		GroupMember: models.ProjectMembersBodyGroup{
 			GroupType: GroupType(d.Get("type").(string)),
 			GroupName: d.Get("group_name").(string),
+			GroupID:   d.Get("group_id").(int),
 		},
 	}
 }

--- a/models/project_members.go
+++ b/models/project_members.go
@@ -10,6 +10,7 @@ type ProjectMembersBody struct {
 type ProjectMembersBodyGroup struct {
 	GroupType int    `json:"group_type,omitempty"`
 	GroupName string `json:"group_name,omitempty"`
+	GroupID   int    `json:"id,omitempty"`
 }
 
 type ProjectMemberUsersGroup struct {

--- a/provider/resource_project_member_group.go
+++ b/provider/resource_project_member_group.go
@@ -19,8 +19,14 @@ func resourceMembersGroup() *schema.Resource {
 			},
 			"group_name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+			},
+			"group_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				AtLeastOneOf: []string{"group_id", "group_name"},
 			},
 			"member_id": {
 				Type:     schema.TypeInt,


### PR DESCRIPTION
Harbor doesn't seem to allow specifying a group name for LDAP groups (I keep getting Error 500). Thus, I'd suggest to specify a numeric ID.

This would work well in conjunction with a Data Provider that searches Harbor for existing User Groups (through the `/usergroups` endpoint, cf. [this branch](https://github.com/lwille/terraform-provider-harbor/tree/project-member-group-id)).

Let me know what you think!

Example:

```terraform
resource "harbor_project_member_group" "infra" {
  project_id = harbor_project.leo-test.id
  group_id   = 11 
  role       = "limitedguest"
  type       = "ldap" 
}
```
