### PR TITLE
Add cli secret

### DIFF
--- a/client/user.go
+++ b/client/user.go
@@ -14,5 +14,6 @@ func UserBody(d *schema.ResourceData) models.UserBody {
 		Email:        d.Get("email").(string),
 		Realname:     d.Get("full_name").(string),
 		Newpassword:  d.Get("password").(string),
+		CLISecret:    d.Get("cli_secret").(string),
 	}
 }

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -26,6 +26,8 @@ The following arguments are supported:
 
 * **admin** - (Optional) If the user will have admin rights within Harbor (Default: **false**)
 
+* **cli_secret** - (Optional) Set the CLI (only works when auth mode is set to 'OIDC')
+
 ## Import
 An internal user harbor user can be imported using the `user id` eg,
 

--- a/models/user.go
+++ b/models/user.go
@@ -21,4 +21,5 @@ type UserBody struct {
 	Salt            string `json:"Salt,omitempty"`
 	Email           string `json:"email,omitempty"`
 	Newpassword     string `json:"new_password,omitempty"`
+	CLISecret       string `json:"secret,omitempty"` // only works when auth mode is set to 'OIDC'
 }

--- a/provider/resource_user.go
+++ b/provider/resource_user.go
@@ -39,6 +39,11 @@ func resourceUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"cli_secret": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
 		},
 		Create: resourceUserCreate,
 		Read:   resourceUserRead,
@@ -86,6 +91,7 @@ func resourceUserRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("email", jsonData.Email)
 	d.Set("admin", jsonData.SysadminFlag)
 	d.Set("comment", jsonData.Comment)
+	d.Set("cli_secret", jsonData.CLISecret)
 
 	return nil
 }
@@ -100,6 +106,11 @@ func resourceUserUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	_, _, err = apiClient.SendRequest("PUT", d.Id()+"/sysadmin", body, 200)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = apiClient.SendRequest("PUT", d.Id()+"/cli_secret", body, 200)
 	if err != nil {
 		return err
 	}

--- a/provider/resource_user_test.go
+++ b/provider/resource_user_test.go
@@ -47,6 +47,8 @@ func TestAccUserBasic(t *testing.T) {
 						resourceHarborUserMain, "full_name", "John Smith"),
 					resource.TestCheckResourceAttr(
 						resourceHarborUserMain, "email", "john.smith@contoso.com"),
+					resource.TestCheckResourceAttr(
+						resourceHarborUserMain, "cli_secret", "my_cli_secret"),
 				),
 			},
 		},
@@ -69,6 +71,8 @@ func TestAccUserUpdate(t *testing.T) {
 						resourceHarborUserMain, "full_name", "John Smith"),
 					resource.TestCheckResourceAttr(
 						resourceHarborUserMain, "email", "john.smith@contoso.com"),
+					resource.TestCheckResourceAttr(
+						resourceHarborUserMain, "cli_secret", "my_cli_secret"),
 				),
 			},
 			{
@@ -81,6 +85,8 @@ func TestAccUserUpdate(t *testing.T) {
 						resourceHarborUserMain, "full_name", "John"),
 					resource.TestCheckResourceAttr(
 						resourceHarborUserMain, "email", "john@contoso.com"),
+					resource.TestCheckResourceAttr(
+						resourceHarborUserMain, "cli_secret", "my_updated_cli_secret"),
 				),
 			},
 		},
@@ -90,10 +96,11 @@ func TestAccUserUpdate(t *testing.T) {
 func testAccCheckUserBasic() string {
 	return fmt.Sprintf(`
 	resource "harbor_user" "main" {
-		username  = "john"
-		password  = "Password12345"
-		full_name = "John Smith"
-		email     = "john.smith@contoso.com"
+		username   = "john"
+		password   = "Password12345"
+		full_name  = "John Smith"
+		email      = "john.smith@contoso.com"
+		cli_secret = "my_cli_secret"
 	  }
 	`)
 }
@@ -105,6 +112,7 @@ func testAccCheckUserUpdate() string {
 		password  = "Password12345!"
 		full_name = "John"
 		email     = "john@contoso.com"
+		cli_secret = "my_updated_cli_secret"
 	  }
 	`)
 }


### PR DESCRIPTION
Hello and thanks for you project.
I need to set the `cli_secret` and implemented what I think should work.
Unfortunately, I do no yet have a test setup with OIDC enabled for checking this.
I adjusted the tests in `provider/resource_user_test.go` but randomly changed stuff so that it *should* fail (not limited to the cli_secret), but my local tests still pass.

So, this is a first request for a review and maybe you already have a dev setup for testing this change.

Regards,
Simon