### PR TITLE
Add event based option to replication policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ terraform*
 .terraform
 example
 *.log
+dist/*

--- a/client/replication.go
+++ b/client/replication.go
@@ -13,9 +13,10 @@ func GetReplicationBody(d *schema.ResourceData) models.ReplicationBody {
 	schedule := d.Get("schedule").(string)
 
 	body := models.ReplicationBody{
-		Name:     d.Get("name").(string),
-		Override: d.Get("override").(bool),
-		Enabled:  d.Get("enabled").(bool),
+		Name:          d.Get("name").(string),
+		Override:      d.Get("override").(bool),
+		Enabled:       d.Get("enabled").(bool),
+		DestNamespace: d.Get("dest_namespace").(string),
 	}
 
 	if action == "push" {
@@ -24,11 +25,17 @@ func GetReplicationBody(d *schema.ResourceData) models.ReplicationBody {
 		body.SrcRegistry.ID = d.Get("registry_id").(int)
 	}
 
-	if schedule != "manual" {
-		body.Trigger.Type = "scheduled"
+	switch schedule {
+	case "manual":
+		body.Trigger.Type = schedule
+
+		break
+	case "event_based":
+		body.Trigger.Type = schedule
+		break
+	default:
+		body.Trigger.Type = "schedule"
 		body.Trigger.TriggerSettings.Cron = schedule
-	} else {
-		body.Trigger.Type = "manual"
 	}
 
 	filters := d.Get("filters").(*schema.Set).List()

--- a/provider/resource_replication.go
+++ b/provider/resource_replication.go
@@ -43,6 +43,10 @@ func resourceReplication() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"dest_namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"override": {
 				Type:     schema.TypeBool,
 				Optional: true,

--- a/provider/resource_retention_policy_test.go
+++ b/provider/resource_retention_policy_test.go
@@ -66,6 +66,27 @@ func TestAccRetentionUpdate(t *testing.T) {
 	})
 }
 
+func TestDestinationNamespace(t *testing.T) {
+	var scheduleType = "event_based"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// CheckDestroy: testAccCheckLabelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testReplicationPolicyDestinationNamespace(scheduleType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(resourceHarborRetentionMain),
+					resource.TestCheckResourceAttr(
+						resourceHarborRetentionMain, "schedule", scheduleType),
+					resource.TestCheckResourceAttr(
+						resourceHarborRetentionMain, "dest_namespace", scheduleType),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRetentionBasic() string {
 	return fmt.Sprintf(`
 	resource "harbor_project" "main" {
@@ -88,4 +109,29 @@ func testAccCheckRetentionBasic() string {
 	  
 	  }
 	`)
+}
+
+func testReplicationPolicyDestinationNamespace(scheduleType string) string {
+	return fmt.Sprintf(`
+	resource "harbor_project" "main" {
+		name                = "acctest_retention_pol"
+	  }
+	  
+	  resource "harbor_retention_policy" "main" {
+		  scope = harbor_project.main.id
+		  schedule = "event_base"
+		  dest_namespace = "%s"
+		  rule {
+			  n_days_since_last_pull = 5
+			  repo_matching = "**"
+			  tag_matching = "latest"
+		  }
+		  rule {
+			  n_days_since_last_push = 10
+			  repo_matching = "**"
+			  tag_matching = "latest"
+		  }
+	  
+	  }
+	`, scheduleType)
 }


### PR DESCRIPTION
 This give the possibility to create a `event based` replication policy and add the mapping for the destination namespace.