### PR TITLE
enable/disable content trust on project

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -27,6 +27,8 @@ func ProjectBody(d *schema.ResourceData) models.ProjectsBodyPost {
 		body.Metadata.PreventVul = "false"
 	}
 
+	body.Metadata.EnableContentTrust = strconv.FormatBool(d.Get("enable_content_trust").(bool))
+
 	cveAllowList := d.Get("cve_allowlist").([]interface{})
 	log.Printf("[DEBUG] %v ", cveAllowList)
 	if len(cveAllowList) > 0 {

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -6,6 +6,7 @@ resource "harbor_project" "main" {
     name                    = "main"
     public                  = false               # (Optional) Default value is false
     vulnerability_scanning  = true                # (Optional) Default vale is true. Automatically scan images on push 
+    enable_content_trust    = true                # (Optional) Default vale is false. Deny unsigned images from being pulled 
 }
 ```
 
@@ -36,6 +37,8 @@ The following arguments are supported:
 * `registry_id` - (Optional) To enabled project as Proxy Cache
 
 * `storage_quota` - (Optional) The storage quota of the project in GB's
+
+* `enable_content_trust` - (Optional) Enables Content Trust for project. When enabled it queries the embedded docker notary server. Can be set to `"true"` or `"false"` (Default: false)
   
 ## Attributes Reference
 In addition to all argument, the following attributes are exported:

--- a/provider/resource_project.go
+++ b/provider/resource_project.go
@@ -54,6 +54,11 @@ func resourceProject() *schema.Resource {
 				},
 				Optional: true,
 			},
+			"enable_content_trust": {
+				Type: schema.TypeBool,
+				Optional: true,
+				Default: false,
+			},
 		},
 		Create: resourceProjectCreate,
 		Read:   resourceProjectRead,
@@ -98,10 +103,16 @@ func resourceProjectRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
+	trust, err := strconv.ParseBool(jsonData.Metadata.EnableContentTrust)
+	if err != nil {
+		return err
+	}
+
 	d.Set("name", jsonData.Name)
 	d.Set("project_id", jsonData.ProjectID)
 	d.Set("public", jsonData.Metadata.Public)
 	d.Set("vulnerability_scanning", vuln)
+	d.Set("enable_content_trust", trust)
 
 	return nil
 }

--- a/provider/resource_project_test.go
+++ b/provider/resource_project_test.go
@@ -46,6 +46,8 @@ func TestAccProjectBasic(t *testing.T) {
 						resourceHarborProjectMain, "public", "false"),
 					resource.TestCheckResourceAttr(
 						resourceHarborProjectMain, "vulnerability_scanning", "false"),
+					resource.TestCheckResourceAttr(
+						resourceHarborProjectMain, "enable_content_trust", "true"),
 				),
 			},
 		},
@@ -68,6 +70,8 @@ func TestAccProjectUpdate(t *testing.T) {
 						resourceHarborProjectMain, "public", "false"),
 					resource.TestCheckResourceAttr(
 						resourceHarborProjectMain, "vulnerability_scanning", "false"),
+					resource.TestCheckResourceAttr(
+						resourceHarborProjectMain, "enable_content_trust", "true"),
 				),
 			},
 			{
@@ -80,6 +84,8 @@ func TestAccProjectUpdate(t *testing.T) {
 						resourceHarborProjectMain, "public", "true"),
 					resource.TestCheckResourceAttr(
 						resourceHarborProjectMain, "vulnerability_scanning", "true"),
+					resource.TestCheckResourceAttr(
+						resourceHarborProjectMain, "enable_content_trust", "true"),
 				),
 			},
 		},
@@ -92,6 +98,7 @@ func testAccCheckProjectBasic() string {
 		name = "test_basic"
 		public = false
 		vulnerability_scanning = false
+		enable_content_trust = false
 	  }
 	`)
 }
@@ -102,6 +109,7 @@ func testAccCheckItemUpdate() string {
 		name = "test_basic"
 		public = true
 		vulnerability_scanning = true
+		enable_content_trust = true
 	  }
 `)
 }


### PR DESCRIPTION
Adding option to enable content trust on project creation. Defaults to false