### PR TITLE
robot full name and some additional configurations

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -14,6 +14,7 @@ func GetConfigSystem(d *schema.ResourceData) models.ConfigBodyPost {
 		ReadOnly:                   d.Get("read_only").(bool),
 		RobotTokenDuration:         days2mins(d.Get("robot_token_expiration").(int)),
 		QuotaPerProjectEnable:      true,
+		RobotNamePrefix:            d.Get("robot_name_prefix").(string),
 	}
 }
 
@@ -35,6 +36,7 @@ func GetConfigAuth(d *schema.ResourceData) models.ConfigBodyPost {
 			OidcVerifyCert:   d.Get("oidc_verify_cert").(bool),
 			OidcAutoOnboard:  d.Get("oidc_auto_onboard").(bool),
 			OidcUserClaim:    d.Get("oidc_user_claim").(string),
+			OidcAdminGroup:   d.Get("oidc_admin_group").(string),
 		}
 	case "ldap_auth", "ldap":
 		body = models.ConfigBodyPost{
@@ -120,6 +122,7 @@ func SetAuthValues(d *schema.ResourceData, resp string) error {
 		d.Set("oidc_verify_cert", jsonData.OidcVerifyCert.Value)
 		d.Set("oidc_auto_onboard", jsonData.OidcAutoOnboard.Value)
 		d.Set("oidc_user_claim", jsonData.OidcUserClaim.Value)
+		d.Set("oidc_admin_group", jsonData.OidcAdminGroup.Value)
 	case "ldap_auth", "ldap":
 		d.Set("ldap_url", jsonData.LdapURL.Value)
 		d.Set("ldap_base_dn", jsonData.LdapBaseDn.Value)

--- a/docs/resources/config_system.md
+++ b/docs/resources/config_system.md
@@ -6,6 +6,7 @@
 resource "harbor_config_system" "main" {
   project_creation_restriction = "adminonly"
   robot_token_expiration       = 30
+  robot_name_prefix            = "harbor@"
 }
 ```
 
@@ -15,5 +16,7 @@ The following arguments are supported:
 * **project_creation_restriction** - (Optional) Who can create projects within Harbor. Can be **"adminonly"** or **"everyone"**
 
 * **robot_token_expiration** - (Optional) The amount of time in days a robot account will expiry. 
+
+* **robot_name_prefix** - (Optional) Robot account prefix.
 
 `NOTE: If the time is set to high you will get a 500 internal server error message when creating robot accounts`

--- a/docs/resources/configuration.md
+++ b/docs/resources/configuration.md
@@ -13,6 +13,7 @@ resource "harbor_config_auth" "oidc" {
   oidc_verify_cert   = true
   oidc_auto_onboard  = true
   oidc_user_claim    = "name"
+  oidc_admin_group   = "administrators"
 }
 ```
 
@@ -52,7 +53,9 @@ The following arguments are supported:
 
 * `oidc_auto_onboard` - (Optional) Default is **"false"**, set to **"true"** if you want to skip the user onboarding screen, so user cannot change its username
 
-* `idc_user_claim` - (Optional) Default is **"name"**
+* `oidc_user_claim` - (Optional) Default is **"name"**
+  
+* `oidc_admin_group` - (Optional) All members of this group get Harbor admin permissions.
 
 
 * `ldap_url` - (Optional) The ldap server. Required when auth_mode is set to ldap.

--- a/docs/resources/robot_account.md
+++ b/docs/resources/robot_account.md
@@ -146,3 +146,4 @@ The following arguments are supported:
 In addition to all argument, the following attributes are exported:
 
 * **secret** - The secret of the robot account used for authentication
+* **full_name** - Full name of the robot account which harbor generates including the robot prefix. Eg. `robot$project+name` or `harbor@project+name` (depending on your robot prefix).

--- a/models/config.go
+++ b/models/config.go
@@ -49,6 +49,8 @@ type ConfigBodyPost struct {
 	RobotTokenDuration         int    `json:"robot_token_duration,omitempty"`
 	LdapVerifyCert             bool   `json:"ldap_verify_cert,omitempty"`
 	LdapGroupGID               string `json:"ldap_group_gid,omitempty"`
+	OidcAdminGroup             string `json:"oidc_admin_group,omitempty"`
+	RobotNamePrefix            string `json:"robot_name_prefix,omitempty"`
 }
 
 type ConfigBodyResponse struct {
@@ -210,4 +212,12 @@ type ConfigBodyResponse struct {
 		Editable bool   `json:"editable,omitempty"`
 		Value    string `json:"value,omitempty"`
 	} `json:"ldap_group_gid,omitempty"`
+	OidcAdminGroup struct {
+		Editable bool   `json:"editable,omitempty"`
+		Value    string `json:"value,omitempty"`
+	} `json:"oidc_admin_group,omitempty"`
+	RobotNamePrefix struct {
+		Editable bool   `json:"editable,omitempty"`
+		Value    string `json:"value,omitempty"`
+	} `json:"robot_name_prefix,omitempty"`
 }

--- a/provider/resource_config_auth.go
+++ b/provider/resource_config_auth.go
@@ -43,6 +43,11 @@ func resourceConfigAuth() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: oidcConflictsWith(),
 			},
+			"oidc_admin_group": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: oidcConflictsWith(),
+			},
 			"oidc_scope": {
 				Type:          schema.TypeString,
 				Optional:      true,

--- a/provider/resource_config_system.go
+++ b/provider/resource_config_system.go
@@ -24,6 +24,10 @@ func resourceConfigSystem() *schema.Resource {
 				Optional: true,
 				Default:  30,
 			},
+			"robot_name_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 		Create: resourceConfigSystemCreate,
 		Read:   resourceConfigSystemRead,

--- a/provider/resource_robot_account.go
+++ b/provider/resource_robot_account.go
@@ -43,6 +43,10 @@ func resourceRobotAccount() *schema.Resource {
 				Optional: true,
 				Default:  -1,
 			},
+			"full_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"secret": {
 				Type:      schema.TypeString,
 				Computed:  true,
@@ -141,6 +145,7 @@ func resourceRobotAccountRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.Set("robot_id", strconv.Itoa(robot.ID))
+	d.Set("full_name", robot.Name)
 
 	return nil
 }


### PR DESCRIPTION
Added `full_name` to the robot_account attributes, so that someone is able to use the harbor generated robot names like `harbor@project+name` within terraform.

Also added the ability to provision the following additional configurations:
- `oidc_admin_group`
- `robot_name_prefix`