### PR TITLE
fix: recreate missing registry

### DIFF
--- a/provider/resource_registry.go
+++ b/provider/resource_registry.go
@@ -85,6 +85,10 @@ func resourceRegistryRead(d *schema.ResourceData, m interface{}) error {
 	apiClient := m.(*client.Client)
 
 	resp, _, err := apiClient.SendRequest("GET", d.Id(), nil, 200)
+	if err != nil {
+		d.SetId("")
+		return nil
+	}
 
 	var jsonData models.RegistryBody
 	err = json.Unmarshal([]byte(resp), &jsonData)


### PR DESCRIPTION
Fixes an issue when the registry can not be recreated if it was deleted outside of the Terraform code.
To reproduce an issue you need to create a registry as it's described in the documentation https://registry.terraform.io/providers/BESTSELLER/harbor/latest/docs/resources/registry
After the creation go to the Harbor web interface, delete the registry, and try to execute terraform plan or terraform apply again.
It will fail with the error: Error: Resource not found

The same fix was applied in PRs #125 and #127