### PR TITLE
fix: typo in API parameters for repo_excluding retention rules

### DIFF
--- a/client/retention.go
+++ b/client/retention.go
@@ -102,7 +102,7 @@ func expandRententionRules(d *schema.ResourceData) []models.Rules {
 			repo.Pattern = i["repo_matching"].(string)
 		}
 		if i["repo_excluding"].(string) != "" {
-			repo.Decoration = "repoMExcludes"
+			repo.Decoration = "repoExcludes"
 			repo.Pattern = i["repo_excluding"].(string)
 		}
 


### PR DESCRIPTION
Fixes an issue when creating retention rules, that use the
`repo_excluding` parameter. Harbors API doesn't validate the generated
JSON when updating the retention policies but fails with an error later
on, when trying to run the policy.