### PR TITLE
fix: replication policies description not propagated to API

### DIFF
--- a/client/replication.go
+++ b/client/replication.go
@@ -14,6 +14,7 @@ func GetReplicationBody(d *schema.ResourceData) models.ReplicationBody {
 
 	body := models.ReplicationBody{
 		Name:          d.Get("name").(string),
+		Description:   d.Get("description").(string),
 		Override:      d.Get("override").(bool),
 		Enabled:       d.Get("enabled").(bool),
 		Deletion:      d.Get("deletion").(bool),


### PR DESCRIPTION
While the fields in the provider representation as also the JSON
representation for the Harbor API where already present, the latter was
never populated from the provider settings, resulting in empty
descriptions when browsing the Harbor API/UI.

fixes #126