### PR TITLE
Rephrase description of `email_insecure` argument

### DIFF
--- a/docs/resources/config_email.md
+++ b/docs/resources/config_email.md
@@ -18,4 +18,4 @@ The following arguments are supported:
 * **email_password** - (Optional) The password for the email server
 * **email_from** - (Required) - The email from address ie, `dont_reply@acme.com` 
 * **email_ssl** - (Optional) Enable SSL for email server connection
-* **email_insecure** - (Optional) Verify Certificate for email server connection
+* **email_insecure** - (Optional) Disables validation of email server certificate `Default: false`


### PR DESCRIPTION
The earlier description made it sound like setting the email_insecure
argument to true would enable verification.

Fixes #132