### PR TITLE
feat: add `force_destroy` attribute to `harbor_project`

### DIFF
--- a/client/project_repositories.go
+++ b/client/project_repositories.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/BESTSELLER/terraform-provider-harbor/models"
+)
+
+// GetProjectRepositories returns a list of repositories for the given project.
+func (c *Client) GetProjectRepositories(projectName string) ([]models.RepositoryBody, error) {
+	var allRepos []models.RepositoryBody
+
+	page := 1
+
+	// Page through the repository list until the API returns an empty result
+	// or an error.
+	for {
+		reposPath := fmt.Sprintf("/projects/%s/repositories?page=%d&page_size=100", projectName, page)
+
+		resp, _, err := c.SendRequest("GET", reposPath, nil, 200)
+		if err != nil {
+			return nil, err
+		}
+
+		var repos []models.RepositoryBody
+
+		if err := json.Unmarshal([]byte(resp), &repos); err != nil {
+			return nil, err
+		}
+
+		if len(repos) == 0 {
+			return allRepos, nil
+		}
+
+		allRepos = append(allRepos, repos...)
+		page++
+	}
+}
+
+// DeleteProjectRepositories deletes all repositories of a given project.
+func (c *Client) DeleteProjectRepositories(projectName string) error {
+	repos, err := c.GetProjectRepositories(projectName)
+	if err != nil {
+		return err
+	}
+
+	// Repository names returned by the API have the form
+	// <project_name>/<repository_name>.
+	projectNamePrefix := fmt.Sprintf("%s/", projectName)
+
+	for _, repo := range repos {
+		repoName := strings.TrimPrefix(repo.Name, projectNamePrefix)
+
+		// Encode slashes in the repository name as mandated by the API.
+		repoName = strings.ReplaceAll(repoName, "/", "%252F")
+
+		repoPath := fmt.Sprintf("/projects/%s/repositories/%s", projectName, repoName)
+
+		_, _, err := c.SendRequest("DELETE", repoPath, nil, 200)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -39,6 +39,8 @@ The following arguments are supported:
 * `storage_quota` - (Optional) The storage quota of the project in GB's
 
 * `enable_content_trust` - (Optional) Enables Content Trust for project. When enabled it queries the embedded docker notary server. Can be set to `"true"` or `"false"` (Default: false)
+
+* `force_destroy` - (Optional, Default: `false`) A boolean that indicates all repositories should be deleted from the project so that the project can be destroyed without error. These repositories are *not* recoverable.
   
 ## Attributes Reference
 In addition to all argument, the following attributes are exported:

--- a/models/repositories.go
+++ b/models/repositories.go
@@ -1,0 +1,11 @@
+package models
+
+type RepositoryBody struct {
+	ArtifactCount int    `json:"artifact_count,omitempty"`
+	ID            int    `json:"id,omitempty"`
+	ProjectID     int    `json:"project_id,omitempty"`
+	PullCount     int    `json:"pull_count,omitempty"`
+	Name          string `json:"name,omitempty"`
+	CreationTime  string `json:"creation_time,omitempty"`
+	UpdateTime    string `json:"update_time,omitempty"`
+}


### PR DESCRIPTION
This change adds the `force_destroy` attribute to the `harbor_project` resource to allow deletion of non-empty projects.

This is similar to how the deletion of non-empty S3 buckets is handled in the `aws` provider: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#force_destroy

Fixes https://github.com/BESTSELLER/terraform-provider-harbor/issues/123