### PR TITLE
Set replication schedule to 'event_based' if that's the trigger type

### DIFF
--- a/provider/resource_replication.go
+++ b/provider/resource_replication.go
@@ -153,6 +153,7 @@ func resourceReplicationRead(d *schema.ResourceData, m interface{}) error {
                         d.Set("schedule", "event_based")
                 default:
                         d.Set("schedule", "manual")
+	}
 
 	d.Set("replication_policy_id", jsonDataReplication.ID)
 	d.Set("enabled", jsonDataReplication.Enabled)

--- a/provider/resource_replication.go
+++ b/provider/resource_replication.go
@@ -146,11 +146,13 @@ func resourceReplicationRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("registry_id", destRegistryID)
 	}
 
-	if jsonDataReplication.Trigger.Type == "scheduled" {
-		d.Set("schedule", jsonDataReplication.Trigger.TriggerSettings.Cron)
-	} else {
-		d.Set("schedule", "manual")
-	}
+	switch jsonDataReplication.Trigger.Type {
+                case "scheduled":
+                        d.Set("schedule", jsonDataReplication.Trigger.TriggerSettings.Cron)
+                case "event_based":
+                        d.Set("schedule", "event_based")
+                default:
+                        d.Set("schedule", "manual")
 
 	d.Set("replication_policy_id", jsonDataReplication.ID)
 	d.Set("enabled", jsonDataReplication.Enabled)


### PR DESCRIPTION
For replication resources, if trigger type is "event_based", set schedule to "event_based" too.

Fixes https://github.com/BESTSELLER/terraform-provider-harbor/issues/180