### PR TITLE
Documentation update: ldap_verify_cert value must be in quotes too

### DIFF
--- a/docs/resources/configuration.md
+++ b/docs/resources/configuration.md
@@ -26,7 +26,7 @@ resource "harbor_config_auth" "ldap" {
   ldap_search_password = "Not@SecurePassw0rd"
   ldap_base_dn         = "dc=example,dc=org"
   ldap_uid             = "email"
-  ldap_verify_cert     = false
+  ldap_verify_cert     = "false"
 }
 ```
 


### PR DESCRIPTION
Confirmed, that without it doesn't work fine. I haven't checked any other false/true values elsewhere, but it might easily happen that it needs to be in quotes elsewhere too.