### PR TITLE
Add maintainer to valid roles

### DIFF
--- a/client/project_members.go
+++ b/client/project_members.go
@@ -51,7 +51,7 @@ func RoleTypeNumber(role int) (x string) {
 	case 3:
 		x = "guest"
 	case 4:
-		x = "master"
+		x = "maintainer"
 	case 5:
 		x = "limitedguest"
 	}
@@ -66,7 +66,7 @@ func RoleType(role string) (x int) {
 		x = 2
 	case "guest":
 		x = 3
-	case "master", "maintainer":
+	case "maintainer":
 		x = 4
 	case "limitedguest":
 		x = 5

--- a/docs/resources/project_member_group.md
+++ b/docs/resources/project_member_group.md
@@ -9,7 +9,7 @@ resource "harbor_project" "main" {
 resource "harbor_project_member_group" "main" {
   project_id    = harbor_project.main.id
   group_name    = "testing1"
-  role          = "master"
+  role          = "projectadmin"
   type          = "oidc"
 }
 

--- a/docs/resources/project_member_user.md
+++ b/docs/resources/project_member_user.md
@@ -9,7 +9,7 @@ resource "harbor_project" "main" {
 resource "harbor_project_member_user" "main" {
   project_id    = harbor_project.main.id
   user_name     = "testing1"
-  role          = "master"
+  role          = "projectadmin"
 }
 
 ```

--- a/provider/resource_project_member_group.go
+++ b/provider/resource_project_member_group.go
@@ -42,9 +42,13 @@ func resourceMembersGroup() *schema.Resource {
 				Required: true,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)
-					if v != "projectadmin" && v != "developer" && v != "guest" && v != "master" && v != "limitedguest" {
-						errs = append(errs, fmt.Errorf("%q must be either projectadmin, developer, guest, limitedguest or master, got: %s", key, v))
+					validRoles := []string{"projectadmin", "maintainer", "developer", "guest", "master", "limitedguest"}
+					for _, r := range validRoles {
+						if v == r {
+							return
+						}
 					}
+					errs = append(errs, fmt.Errorf("%q must be one of %v, got: %s", key, validRoles, v))
 					return
 				},
 			},

--- a/provider/resource_project_member_group.go
+++ b/provider/resource_project_member_group.go
@@ -42,7 +42,7 @@ func resourceMembersGroup() *schema.Resource {
 				Required: true,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)
-					validRoles := []string{"projectadmin", "maintainer", "developer", "guest", "master", "limitedguest"}
+					validRoles := []string{"projectadmin", "developer", "guest", "maintainer", "limitedguest"}
 					for _, r := range validRoles {
 						if v == r {
 							return

--- a/provider/resource_project_member_user.go
+++ b/provider/resource_project_member_user.go
@@ -32,7 +32,7 @@ func resourceMembersUser() *schema.Resource {
 				Required: true,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)
-					validRoles := []string{"projectadmin", "maintainer", "developer", "guest", "master", "limitedguest"}
+					validRoles := []string{"projectadmin", "developer", "guest", "maintainer", "limitedguest"}
 					for _, r := range validRoles {
 						if v == r {
 							return

--- a/provider/resource_project_member_user.go
+++ b/provider/resource_project_member_user.go
@@ -32,9 +32,13 @@ func resourceMembersUser() *schema.Resource {
 				Required: true,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)
-					if v != "projectadmin" && v != "developer" && v != "guest" && v != "master" && v != "limitedguest" {
-						errs = append(errs, fmt.Errorf("%q must be either projectadmin, developer, guest, limitedguest or master, got: %s", key, v))
+					validRoles := []string{"projectadmin", "maintainer", "developer", "guest", "master", "limitedguest"}
+					for _, r := range validRoles {
+						if v == r {
+							return
+						}
 					}
+					errs = append(errs, fmt.Errorf("%q must be one of %v, got: %s", key, validRoles, v))
 					return
 				},
 			},


### PR DESCRIPTION
Looks like the PR referenced in https://github.com/BESTSELLER/terraform-provider-harbor/issues/53 for supporting maintainer role is missing updating this check.

My Go skills are not the best but I tested the changes locally and everything seems to work fine:

Changing a role to maintainer:

![image](https://user-images.githubusercontent.com/15369573/164502059-3897bccb-2fb0-414d-9fa9-66c1a3e7dbef.png)

Using an unsupported `administrator` role:

![image](https://user-images.githubusercontent.com/15369573/164502312-f4ba69dc-71d2-4ae8-bdbe-45132289d839.png)

I had to drop support for the `master` role (which no longer exists in Harbor >= 2.1.0) to avoid a constant drift where Terraform was retrieving live "maintainer" roles as "master" since both use `4` as role id.

So I guess this would be a breaking change by dropping support to Harbor versions < 2.1.0. If you have any other suggestions on how to handle this, please let me know.

Cheers!