### PR TITLE
fix harbor project quota update bug

### DIFF
--- a/models/quota.go
+++ b/models/quota.go
@@ -1,8 +1,25 @@
 package models
 
+import "time"
+
 type StorageQuota struct {
 	Hard Hard `json:"hard"`
 }
 type Hard struct {
 	Storage int64 `json:"storage"`
+}
+type Used struct {
+	Storage int64 `json:"storage"`
+}
+type QuotaResponse struct {
+	CreationTime	time.Time	`json:"creation_time"`
+	Hard		Hard		`json:"hard"`
+	ID		int		`json:"id"`
+	Ref struct {
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Owner string `json:"owner"`
+        } `json:"ref"`
+	UpdateTime	time.Time	`json:"update_time"`
+	Used		Used		`json:"used"`
 }


### PR DESCRIPTION
Fix harbor project quota update bug, where project quota ID was treated the same as project ID, which is not correct. quotaID in many cases could be different from projectID. 

Fixes https://github.com/BESTSELLER/terraform-provider-harbor/issues/211 (a new open issue), which is the same issue as https://github.com/BESTSELLER/terraform-provider-harbor/issues/152 (already closed). 